### PR TITLE
DEVOP-13 : FIX assert security issue on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything).
 
 **Required** Github token of the repository (automatically created by Github)
 
-### `has_bandit_yaml`
+### `use_bandit_yaml`
 
-**Optional** set to true if bandit.yaml file is used. bandit.yaml file is expected at the path variable location. if not set, has_bandit_yaml is set to false.
+**Optional** set to true if bandit.yaml file is used. bandit.yaml file is expected at the path variable location. if not set, use_bandit_yaml is set to false.
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything).
 
 **Required** Github token of the repository (automatically created by Github)
 
+### `has_bandit_yaml`
+
+**Optional** set to true if bandit.yaml file is used. bandit.yaml file is expected at the path variable location. if not set, has_bandit_yaml is set to false.
 
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker://mglivn/action-bandit'
+  image: 'docker://mglivn/action-bandit:DEVOP-13'
   args:
     - ${{ inputs.path }}
     - ${{ inputs.level }}

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
   GITHUB_TOKEN:
     description: 'Github token of the repository (automatically created by Github)'
     required: true
+  use_bandit_yaml:
+    description: 'set to true if bandit.yaml file is used. expected to be at the root of the path variable'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'docker://mglivn/action-bandit:DEVOP-13'
@@ -53,3 +57,4 @@ runs:
     - ${{ inputs.ini_path }}
     - ${{ inputs.format }}
     - ${{ inputs.output }}
+    - ${{ inputs.use_bandit_yaml }}

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker://epsylabs/action-bandit'
+  image: 'docker://mglivn/action-bandit'
   args:
     - ${{ inputs.path }}
     - ${{ inputs.level }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     default: 'false'
 runs:
   using: 'docker'
-  image: 'docker://mglivn/action-bandit:DEVOP-13'
+  image: 'docker://epsylabs/action-bandit'
   args:
     - ${{ inputs.path }}
     - ${{ inputs.level }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,9 +60,9 @@ fi
 
 bandit --version
 
-echo "has_bandit_yaml is - $10"
+echo "has_bandit_yaml is - ${10}"
 
-if [ "$10" == "true" ]; then
+if [ "${10}" == "true" ]; then
     bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
 else
     bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,10 @@ else
 fi
 
 if [ "${10}" == "true" ]; then
-    bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+    USE_BANDIT_YAML="-c bandit.yaml"
 else
-    bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+    USE_BANDIT_YAML=""
 fi
+
+bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH $USE_BANDIT_YAML --exit-zero
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#./entrypoint.sh . high high ./.venv 0 DEFAULT DEFAULT format path
+#./entrypoint.sh . high high ./.venv 0 DEFAULT DEFAULT format path has_bandit_yaml
 
 UPPERCASE_LEVEL=$(echo $2 | tr a-z A-Z)
 case $UPPERCASE_LEVEL in
@@ -58,5 +58,8 @@ else
     INI_PATH="--ini $7"
 fi
 
-
-bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+if [ "$8" == "true" ] || [ "$8" == "TRUE" ]; then
+    bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+else
+    bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,4 +59,4 @@ else
 fi
 
 
-bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
+bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ else
     INI_PATH="--ini $7"
 fi
 
-if [ "$8" == "true" ] || [ "$8" == "TRUE" ]; then
+if [ "$10" == "true" ] || [ "$10" == "TRUE" ]; then
     bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
 else
     bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 #./entrypoint.sh . high high ./.venv 0 DEFAULT DEFAULT format path has_bandit_yaml
 
+bandit --version
+
 UPPERCASE_LEVEL=$(echo $2 | tr a-z A-Z)
 case $UPPERCASE_LEVEL in
 LOW)
@@ -57,10 +59,6 @@ if [ "$7" == "DEFAULT" ]; then
 else
     INI_PATH="--ini $7"
 fi
-
-bandit --version
-
-echo "has_bandit_yaml is - ${10}"
 
 if [ "${10}" == "true" ]; then
     bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,11 @@ else
     INI_PATH="--ini $7"
 fi
 
-if [ "$10" == "true" ] || [ "$10" == "TRUE" ]; then
+bandit --version
+
+echo "has_bandit_yaml is - $10"
+
+if [ "$10" == "true" ]; then
     bandit -c bandit.yaml -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero
 else
     bandit -f $8 -o $9 -r $1 $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH --exit-zero


### PR DESCRIPTION

Introduced a flag to set bandit.yaml file for bandit configurations. 

why bandit.yaml file instead of using .bandit?
.bandit file configuration to exclude tests folder did not work well. If I set to skip a rule, it is applied everywhere - which means an assert is skipped in code as well (not just tests folder). 